### PR TITLE
Use group updates for dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,3 +9,8 @@ updates:
     directory: "/" # Location of package manifests
     schedule:
       interval: "weekly"
+    groups:
+      # This is the name of your group, it will be used in PR titles and branch names
+      dependencies:
+        patterns:
+          - "*"


### PR DESCRIPTION
## Description

This PR allows group upgrades of dependencies done by Dependabot. It will create one PR per scheduled interval instead of 1 PR per gem update. Based on https://github.blog/changelog/2023-06-30-grouped-version-updates-for-dependabot-public-beta/


## Type of Change

* New feature (non-breaking change which adds functionality)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
